### PR TITLE
Add support for experimental messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Transcripts are an array of transcript objects. Each transcript has the followin
 | text     | string  | Text transcript of the speech from the end user or the agent.                                                             |
 | isFinal  | boolean | True if the transcript represents a complete utterance. False if it is a fragment of an utterance that is still underway. |
 | speaker  | Role    | Either "user" or "agent". Denotes who was speaking.                                                                       |
-| medium   | Medium  | Either "voice" or "text". Denotes how the message was sent.                                                                           |
+| medium   | Medium  | Either "voice" or "text". Denotes how the message was sent.                                                               |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ultravox-client",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "private": false,
   "files": [
     "dist"


### PR DESCRIPTION
This gives us a means to quickly expose new messages for specific use cases without expanding the SDK surface area until a feature is hardened enough to ship.