### PR TITLE
Levi/initial mute state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ export class UltravoxSession extends EventTarget {
 
   private _isMicMuted: boolean = false;
   private _isSpeakerMuted: boolean = false;
-  private initialMicMuted: boolean | null = null;
+  private _initialMicMuted: boolean | null = null;
 
   /**
    * Constructor for UltravoxSession.
@@ -209,7 +209,7 @@ export class UltravoxSession extends EventTarget {
       this.room.localParticipant.setMicrophoneEnabled(!muted);
     } else {
       // Store for connection
-      this.initialMicMuted = muted;
+      this._initialMicMuted = muted;
     }
   }
 
@@ -395,9 +395,9 @@ export class UltravoxSession extends EventTarget {
     const opts = { name: 'audio', simulcast: false, source: Track.Source.Microphone };
     this.room.localParticipant.publishTrack(this.localAudioTrack, opts);
 
-    if (this.initialMicMuted !== null) {
-      this.room.localParticipant.setMicrophoneEnabled(!this.initialMicMuted);
-      this.initialMicMuted = null; // Reset after applying
+    if (this._initialMicMuted !== null) {
+      this.room.localParticipant.setMicrophoneEnabled(!this._initialMicMuted);
+      this._initialMicMuted = null; // Reset after applying
     }
 
     this.setStatus(UltravoxSessionStatus.IDLE);


### PR DESCRIPTION
This adds a method allowing you to set the initial mute state before starting the call. 

This is to resolve the issue where blocky can be interrupted when the call first starts. 