### PR TITLE
Modernize sendText, expose audio source nodes, harden teardown, bump deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      # src/version.ts is gitignored but needed by the tshy build that runs on install.
-      - run: pnpm run prepublishOnly
       - run: pnpm install --frozen-lockfile
       - run: pnpm run format:check
       - run: pnpm exec tsc --noEmit

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ session.joinCall('wss://your-call-join-url');
 session.leaveCall();
 ```
 
-_Note: Join URL's are created using the Ultravox API. See the [docs](https://docs.ultravox.ai) for more info._
+_Note: Join URLs are created using the Ultravox API. See the [docs](https://docs.ultravox.ai) for more info._
 
 ## Events
 
@@ -123,18 +123,11 @@ audio pending a user gesture, resume the context after the next gesture.
 
 ## Testing SDK Versions
 
-This repo includes a basic example application that can be used with the SDK. The example application requires running a local web server:
+This repo includes a basic example application that can be used with the SDK. It always runs
+against the SDK built from your local checkout:
 
 ```bash
 pnpm serve-example
 ```
 
 Then navigate your browser to `http://localhost:8080/example/` and use the example.
-
-### Missing version.js file
-
-If build fails because it cannot find './version.js', run the following:
-
-```bash
-pnpm publish --dry-run --git-checks=false
-```

--- a/README.md
+++ b/README.md
@@ -96,22 +96,30 @@ session.sendText('The user tapped the checkout button', { urgency: TextMessageUr
 ```
 
 Arbitrary [data messages](https://docs.ultravox.ai/datamessages) can also be sent with
-`session.sendData(message)`, and every message received from the server is emitted as a
-`data_message` event on the session (calling `preventDefault()` on that event suppresses the
-SDK's default handling of the message).
+`session.sendData(message)`, and every data message received after the call connects is emitted
+as a `data_message` event on the session (calling `preventDefault()` on that event suppresses
+the SDK's default handling of the message).
 
 ## Speech Indicators and Audio Analysis
 
 The session exposes Web Audio source nodes for both sides of the conversation, for example for
 attaching an `AnalyserNode` to drive speech indicators. Both are undefined until the relevant
 audio exists — typically shortly after the call connects (and, for the mic, after the user grants
-permission) — and belong to the session's `AudioContext` (which you can pass to the constructor
-if you'd rather own it).
+permission). The nodes belong to the session's `AudioContext`, and Web Audio nodes from different
+contexts cannot be connected, so provide the context yourself when you want to attach your own
+nodes:
 
 ```javascript
+const audioContext = new AudioContext();
+const session = new UltravoxSession({ audioContext });
+
+// Then, once the call's audio is flowing:
 const analyser = audioContext.createAnalyser();
-session.agentSourceNode.connect(analyser); // Or micSourceNode for the user's audio.
+session.agentSourceNode?.connect(analyser); // Or micSourceNode for the user's audio.
 ```
+
+Note that the nodes produce data only while the `AudioContext` is running; if the browser blocked
+audio pending a user gesture, resume the context after the next gesture.
 
 ## Testing SDK Versions
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ session.joinCall('wss://your-call-join-url');
 session.leaveCall();
 ```
 
-_Note: Join URL's are created using the Ultravox API. See the [docs](https://docs.fixie.ai) for more info._
+_Note: Join URL's are created using the Ultravox API. See the [docs](https://docs.ultravox.ai) for more info._
 
 ## Events
 
@@ -78,6 +78,40 @@ Transcripts are an array of transcript objects. Each transcript has the followin
 | isFinal  | boolean | True if the transcript represents a complete utterance. False if it is a fragment of an utterance that is still underway. |
 | speaker  | Role    | Either "user" or "agent". Denotes who was speaking.                                                                       |
 | medium   | Medium  | Either "voice" or "text". Denotes how the message was sent.                                                               |
+| ordinal  | number  | The position of the message within the call, for sorting.                                                                 |
+
+## Sending Text
+
+Text can be sent to the agent during a call:
+
+```javascript
+import { TextMessageUrgency } from 'ultravox-client';
+
+session.sendText('Show me my order history');
+
+// Urgency controls how soon the agent responds: IMMEDIATE (interrupt the agent if it is
+// speaking), SOON (respond at the next opportunity, the default), or LATER (don't force a
+// response; the message is simply included the next time the agent responds).
+session.sendText('The user tapped the checkout button', { urgency: TextMessageUrgency.LATER });
+```
+
+Arbitrary [data messages](https://docs.ultravox.ai/datamessages) can also be sent with
+`session.sendData(message)`, and every message received from the server is emitted as a
+`data_message` event on the session (calling `preventDefault()` on that event suppresses the
+SDK's default handling of the message).
+
+## Speech Indicators and Audio Analysis
+
+The session exposes Web Audio source nodes for both sides of the conversation, for example for
+attaching an `AnalyserNode` to drive speech indicators. Both are undefined until the relevant
+audio exists — typically shortly after the call connects (and, for the mic, after the user grants
+permission) — and belong to the session's `AudioContext` (which you can pass to the constructor
+if you'd rather own it).
+
+```javascript
+const analyser = audioContext.createAnalyser();
+session.agentSourceNode.connect(analyser); // Or micSourceNode for the user's audio.
+```
 
 ## Testing SDK Versions
 

--- a/example/index.js
+++ b/example/index.js
@@ -7,35 +7,37 @@ class UltravoxExample {
     this.setUpEventListeners();
   }
 
-  appendUpdate(target, message) {
-    const updateTarget = document.getElementById(target);
+  updateStatus(message) {
+    document.getElementById('callStatus').textContent = `Call Status: ${message}`;
+  }
 
-    if (target === 'callTranscript') {
-      let transcriptText = '';
-      message.forEach((transcript, index) => {
-        if (transcript.speaker === 'agent') {
-          transcriptText += '<p>' + transcript.speaker + ': ' + transcript.text + '</p>';
-        }
-      });
-      updateTarget.innerHTML = transcriptText;
-      updateTarget.scrollTop = updateTarget.scrollHeight;
-    } else {
-      updateTarget.innerHTML = `<p>Call Status: ${message}</p>`;
-    }
+  renderTranscripts() {
+    // The session's transcripts array is the source of truth: it already merges partial
+    // utterances and is emptied when the session is reused for a new call, so rendering it
+    // wholesale keeps this display correct without tracking any state here.
+    const container = document.getElementById('callTranscript');
+    container.replaceChildren(
+      ...this.uvSession.transcripts.map((transcript) => {
+        const paragraph = document.createElement('p');
+        paragraph.textContent = `${transcript.speaker}: ${transcript.text}`;
+        return paragraph;
+      }),
+    );
+    container.scrollTop = container.scrollHeight;
   }
 
   setUpEventListeners() {
     // Set up session event listeners
-    this.uvSession.addEventListener('status', (event) => {
-      this.appendUpdate('callStatus', `Session status changed: ${this.uvSession.status}`);
+    this.uvSession.addEventListener('status', () => {
+      this.updateStatus(`Session status changed: ${this.uvSession.status}`);
     });
 
-    this.uvSession.addEventListener('transcripts', (event) => {
-      this.appendUpdate('callTranscript', this.uvSession.transcripts);
+    this.uvSession.addEventListener('transcripts', () => {
+      this.renderTranscripts();
     });
 
     this.uvSession.addEventListener('error', (event) => {
-      this.appendUpdate('callStatus', `Session ended unexpectedly: ${event.error.message}`);
+      this.updateStatus(`Session ended unexpectedly: ${event.error.message}`);
     });
 
     this.uvSession.addEventListener('video_track_subscribed', (event) => {
@@ -46,7 +48,7 @@ class UltravoxExample {
       videoElement.style.right = '0';
       videoElement.style.width = '600px';
       document.body.appendChild(videoElement);
-      this.appendUpdate('callStatus', 'Video track subscribed');
+      this.updateStatus('Video track subscribed');
     });
 
     // Set up button click handlers
@@ -57,18 +59,18 @@ class UltravoxExample {
   startCall = async () => {
     const joinUrl = document.getElementById('joinUrl').value;
     if (!joinUrl) {
-      this.appendUpdate('callStatus', 'Please enter a valid join URL');
+      this.updateStatus('Please enter a valid join URL');
       return;
     }
 
-    this.appendUpdate('callStatus', 'Starting call');
+    this.updateStatus('Starting call');
     this.uvSession.registerToolImplementation('getSecretMenu', this.getSecretMenu);
     this.uvSession.joinCall(joinUrl);
-    this.appendUpdate('callStatus', `Joining call: ${this.uvSession.status}`);
+    this.updateStatus(`Joining call: ${this.uvSession.status}`);
   };
 
   endCall = async () => {
-    this.appendUpdate('callStatus', 'Ending call');
+    this.updateStatus('Ending call');
     this.uvSession.leaveCall();
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ultravox-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": false,
   "files": [
     "dist"
@@ -27,13 +27,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "livekit-client": "^2.16.1"
+    "livekit-client": "^2.20.1"
   },
   "devDependencies": {
     "http-server": "^14.1.1",
-    "prettier": "^3.7.4",
-    "tshy": "^3.1.0",
-    "typescript": "^5.9.3",
+    "prettier": "^3.9.4",
+    "tshy": "^4.1.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     }
   },
   "scripts": {
-    "prepublishOnly": "node -p \"'export const ULTRAVOX_SDK_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
+    "gen-version": "node -p \"'export const ULTRAVOX_SDK_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "build": "pnpm run prepare && pnpm run format",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "tshy",
-    "serve-example": "http-server",
+    "prepare": "pnpm run gen-version && tshy",
+    "serve-example": "pnpm run prepare && http-server",
     "test": "vitest run"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,21 +8,21 @@ importers:
   .:
     dependencies:
       livekit-client:
-        specifier: ^2.16.1
-        version: 2.16.1(@types/dom-mediacapture-record@1.0.22)
+        specifier: ^2.20.1
+        version: 2.20.1(@types/dom-mediacapture-record@1.0.22)
     devDependencies:
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
       prettier:
-        specifier: ^3.7.4
-        version: 3.7.4
+        specifier: ^3.9.4
+        version: 3.9.4
       tshy:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^4.1.3
+        version: 4.1.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(vite@8.1.3)
@@ -54,11 +54,6 @@ packages:
       { integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA== }
     engines: { node: 20 || >=22 }
 
-  '@isaacs/cliui@8.0.2':
-    resolution:
-      { integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA== }
-    engines: { node: '>=12' }
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution:
       { integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og== }
@@ -67,9 +62,9 @@ packages:
     resolution:
       { integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw== }
 
-  '@livekit/protocol@1.42.2':
+  '@livekit/protocol@1.46.6':
     resolution:
-      { integrity: sha512-0jeCwoMJKcwsZICg5S6RZM4xhJoF78qMvQELjACJQn6/VB+jmiySQKOSELTXvPBVafHfEbMlqxUw2UR1jTXs2g== }
+      { integrity: sha512-upzlHP1vi/kZ/QqALZTFskQ0ifqc2f15RKucHYOsIHJsaXvEYanG75mAb7o+Yomfs4XhQ4BaRsdY+TFHXpaqrg== }
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution:
@@ -81,11 +76,6 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution:
       { integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw== }
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution:
-      { integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg== }
-    engines: { node: '>=14' }
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution:
@@ -219,6 +209,201 @@ packages:
     resolution:
       { integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg== }
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    resolution:
+      { integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    resolution:
+      { integrity: sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    resolution:
+      { integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    resolution:
+      { integrity: sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    resolution:
+      { integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    resolution:
+      { integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    resolution:
+      { integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    resolution:
+      { integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg== }
+    engines: { node: '>=16.20.0' }
+    hasBin: true
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution:
+      { integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution:
+      { integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution:
+      { integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution:
+      { integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution:
+      { integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution:
+      { integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution:
+      { integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution:
+      { integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution:
+      { integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA== }
+    engines: { node: '>=16.20.0' }
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution:
+      { integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA== }
+    engines: { node: '>=16.20.0' }
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution:
+      { integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution:
+      { integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw== }
+    engines: { node: '>=16.20.0' }
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution:
+      { integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution:
+      { integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution:
+      { integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution:
+      { integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution:
+      { integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution:
+      { integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution:
+      { integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ== }
+    engines: { node: '>=16.20.0' }
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution:
+      { integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g== }
+    engines: { node: '>=16.20.0' }
+    cpu: [x64]
+    os: [win32]
+
   '@vitest/expect@4.1.10':
     resolution:
       { integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA== }
@@ -255,25 +440,10 @@ packages:
     resolution:
       { integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA== }
 
-  ansi-regex@5.0.1:
-    resolution:
-      { integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ== }
-    engines: { node: '>=8' }
-
-  ansi-regex@6.0.1:
-    resolution:
-      { integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA== }
-    engines: { node: '>=12' }
-
   ansi-styles@4.3.0:
     resolution:
       { integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg== }
     engines: { node: '>=8' }
-
-  ansi-styles@6.2.1:
-    resolution:
-      { integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug== }
-    engines: { node: '>=12' }
 
   assertion-error@2.0.1:
     resolution:
@@ -284,10 +454,20 @@ packages:
     resolution:
       { integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA== }
 
+  balanced-match@4.0.4:
+    resolution:
+      { integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA== }
+    engines: { node: 18 || 20 || >=22 }
+
   basic-auth@2.0.1:
     resolution:
       { integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg== }
     engines: { node: '>= 0.8' }
+
+  brace-expansion@5.0.7:
+    resolution:
+      { integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA== }
+    engines: { node: 18 || 20 || >=22 }
 
   call-bind@1.0.7:
     resolution:
@@ -332,11 +512,6 @@ packages:
       { integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ== }
     engines: { node: '>= 0.4.0' }
 
-  cross-spawn@7.0.6:
-    resolution:
-      { integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA== }
-    engines: { node: '>= 8' }
-
   debug@3.2.7:
     resolution:
       { integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ== }
@@ -355,18 +530,6 @@ packages:
     resolution:
       { integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ== }
     engines: { node: '>=8' }
-
-  eastasianwidth@0.2.0:
-    resolution:
-      { integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA== }
-
-  emoji-regex@8.0.0:
-    resolution:
-      { integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A== }
-
-  emoji-regex@9.2.2:
-    resolution:
-      { integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg== }
 
   es-define-property@1.0.0:
     resolution:
@@ -420,10 +583,10 @@ packages:
       debug:
         optional: true
 
-  foreground-child@3.3.1:
+  foreground-child@4.0.3:
     resolution:
-      { integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw== }
-    engines: { node: '>=14' }
+      { integrity: sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw== }
+    engines: { node: '>=16' }
 
   fsevents@2.3.3:
     resolution:
@@ -440,11 +603,10 @@ packages:
       { integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ== }
     engines: { node: '>= 0.4' }
 
-  glob@11.0.0:
+  glob@13.0.6:
     resolution:
-      { integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g== }
-    engines: { node: 20 || >=22 }
-    hasBin: true
+      { integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw== }
+    engines: { node: 18 || 20 || >=22 }
 
   gopd@1.1.0:
     resolution:
@@ -501,23 +663,13 @@ packages:
       { integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw== }
     engines: { node: '>=0.10.0' }
 
-  is-fullwidth-code-point@3.0.0:
-    resolution:
-      { integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg== }
-    engines: { node: '>=8' }
-
-  isexe@2.0.0:
-    resolution:
-      { integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw== }
-
-  jackspeak@4.0.1:
-    resolution:
-      { integrity: sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog== }
-    engines: { node: 20 || >=22 }
-
   jose@6.1.3:
     resolution:
       { integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ== }
+
+  jsonc-simple-parser@3.0.0:
+    resolution:
+      { integrity: sha512-0qi9Kuj4JPar4/3b9wZteuPZrTeFzXsQyOZj7hksnReCZN3Vr17Doz7w/i3E9XH7vRkVTHhHES+r1h97I+hfww== }
 
   lightningcss-android-arm64@1.32.0:
     resolution:
@@ -601,9 +753,9 @@ packages:
       { integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ== }
     engines: { node: '>= 12.0.0' }
 
-  livekit-client@2.16.1:
+  livekit-client@2.20.1:
     resolution:
-      { integrity: sha512-PmOHiGdkzw2P/t0vLbJRwHU59+T+JcFlGTYDV7PObWmzvypIij1Vlj0WhZKDZ/Ac7CvwWinbiGCVw/Pb/OiYYw== }
+      { integrity: sha512-JxooxLFMkdwqTo4XLer+DCij6S3//Z/GuHSjqdhlj94Vtbh1Eayd7Lyq47qkIE86+xVJhqxIdYnq53lg4oPH9w== }
     peerDependencies:
       '@types/dom-mediacapture-record': ^1
 
@@ -636,6 +788,11 @@ packages:
       { integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ== }
     engines: { node: 20 || >=22 }
 
+  minimatch@10.2.5:
+    resolution:
+      { integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg== }
+    engines: { node: 18 || 20 || >=22 }
+
   minimist@1.2.8:
     resolution:
       { integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA== }
@@ -643,6 +800,11 @@ packages:
   minipass@7.1.2:
     resolution:
       { integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw== }
+    engines: { node: '>=16 || 14 >=14.17' }
+
+  minipass@7.1.3:
+    resolution:
+      { integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A== }
     engines: { node: '>=16 || 14 >=14.17' }
 
   mkdirp@0.5.6:
@@ -681,19 +843,19 @@ packages:
       { integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A== }
     hasBin: true
 
-  package-json-from-dist@1.0.0:
+  package-json-from-dist@1.0.1:
     resolution:
-      { integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw== }
-
-  path-key@3.1.1:
-    resolution:
-      { integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q== }
-    engines: { node: '>=8' }
+      { integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw== }
 
   path-scurry@2.0.0:
     resolution:
       { integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg== }
     engines: { node: 20 || >=22 }
+
+  path-scurry@2.0.2:
+    resolution:
+      { integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg== }
+    engines: { node: 18 || 20 || >=22 }
 
   pathe@2.0.3:
     resolution:
@@ -723,9 +885,9 @@ packages:
       { integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg== }
     engines: { node: ^10 || ^12 || >=14 }
 
-  prettier@3.7.4:
+  prettier@3.9.4:
     resolution:
-      { integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA== }
+      { integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg== }
     engines: { node: '>=14' }
     hasBin: true
 
@@ -739,18 +901,22 @@ packages:
       { integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg== }
     engines: { node: '>= 14.18.0' }
 
+  reghex@3.0.2:
+    resolution:
+      { integrity: sha512-Zb9DJ5u6GhgqRSBnxV2QSnLqEwcKxHWFA1N2yUa4ZUAO1P8jlWKYtWZ6/ooV6yylspGXJX0O/uNzEv0xrCtwaA== }
+
   requires-port@1.0.0:
     resolution:
       { integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ== }
 
-  resolve-import@2.0.0:
+  resolve-import@2.4.0:
     resolution:
-      { integrity: sha512-jpKjLibLuc8D1XEV2+7zb0aqN7I8d12u89g/v6IsgCzdVlccMQJq4TKkPw5fbhHdxhm7nbVtN+KvOTnjFf+nEA== }
+      { integrity: sha512-gLWKdA5tiv5j/D7ipR47u3ovbVfzFPrctTdw2Ulnpmr6PPVVSvPKGNWu09jXVNlOSLLAeD6CA13bjIelpWttSw== }
     engines: { node: 20 || >=22 }
 
-  rimraf@6.0.1:
+  rimraf@6.1.3:
     resolution:
-      { integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A== }
+      { integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA== }
     engines: { node: 20 || >=22 }
     hasBin: true
 
@@ -790,16 +956,6 @@ packages:
       { integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg== }
     engines: { node: '>= 0.4' }
 
-  shebang-command@2.0.0:
-    resolution:
-      { integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA== }
-    engines: { node: '>=8' }
-
-  shebang-regex@3.0.0:
-    resolution:
-      { integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A== }
-    engines: { node: '>=8' }
-
   side-channel@1.0.6:
     resolution:
       { integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA== }
@@ -827,34 +983,14 @@ packages:
     resolution:
       { integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw== }
 
-  string-width@4.2.3:
-    resolution:
-      { integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g== }
-    engines: { node: '>=8' }
-
-  string-width@5.1.2:
-    resolution:
-      { integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA== }
-    engines: { node: '>=12' }
-
-  strip-ansi@6.0.1:
-    resolution:
-      { integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A== }
-    engines: { node: '>=8' }
-
-  strip-ansi@7.1.0:
-    resolution:
-      { integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ== }
-    engines: { node: '>=12' }
-
   supports-color@7.2.0:
     resolution:
       { integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw== }
     engines: { node: '>=8' }
 
-  sync-content@2.0.1:
+  sync-content@2.0.4:
     resolution:
-      { integrity: sha512-NI1mo514yFhr8pV/5Etvgh+pSBUIpoAKoiBIUwALVlQQNAwb40bTw8hhPFaip/dvv0GhpHVOq0vq8iY02ppLTg== }
+      { integrity: sha512-w3ioiBmbaogob33WdLnuwFk+8tpePI58CTWKqtdAgEqc2hfGuSwP02gPETqNX/3PLS5skv5a1wQR0gbaa2W0XQ== }
     engines: { node: 20 || >=22 }
     hasBin: true
 
@@ -877,13 +1013,9 @@ packages:
       { integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw== }
     engines: { node: '>=14.0.0' }
 
-  ts-debounce@4.0.0:
+  tshy@4.1.3:
     resolution:
-      { integrity: sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg== }
-
-  tshy@3.1.0:
-    resolution:
-      { integrity: sha512-DPBaaJSqcKFLSHTiqm3Xl2Phl7m1RtLNMe7J8qyoYO+tb2EW+txRp2NHR746GcrVicUUcNzfpm0yU1suQHRIwQ== }
+      { integrity: sha512-uEaLO1lFhu5X58KZxS5gKCabh+xd72MfXDOHhAIvnoreBAP1F4HNpbK2m0DUmrrzpcgxvXbsdXn1A0OaQxFYqw== }
     engines: { node: 20 || >=22 }
     hasBin: true
 
@@ -895,10 +1027,16 @@ packages:
     resolution:
       { integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA== }
 
-  typescript@5.9.3:
+  typescript@6.0.3:
     resolution:
-      { integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw== }
+      { integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw== }
     engines: { node: '>=14.17' }
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution:
+      { integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA== }
+    engines: { node: '>=16.20.0' }
     hasBin: true
 
   union@0.5.0:
@@ -1001,9 +1139,9 @@ packages:
       { integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A== }
     engines: { node: 20 || >=22 }
 
-  webrtc-adapter@9.0.1:
+  webrtc-adapter@9.0.6:
     resolution:
-      { integrity: sha512-1AQO+d4ElfVSXyzNVTOewgGT/tAomwwztX/6e3totvyyzXPvXIIuUUjAmyZGbKBKbZOXauuJooZm3g6IuFuiNQ== }
+      { integrity: sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog== }
     engines: { node: '>=6.0.0', npm: '>=3.10.0' }
 
   whatwg-encoding@2.0.0:
@@ -1011,27 +1149,11 @@ packages:
       { integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg== }
     engines: { node: '>=12' }
 
-  which@2.0.2:
-    resolution:
-      { integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA== }
-    engines: { node: '>= 8' }
-    hasBin: true
-
   why-is-node-running@2.3.0:
     resolution:
       { integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w== }
     engines: { node: '>=8' }
     hasBin: true
-
-  wrap-ansi@7.0.0:
-    resolution:
-      { integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q== }
-    engines: { node: '>=10' }
-
-  wrap-ansi@8.1.0:
-    resolution:
-      { integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ== }
-    engines: { node: '>=12' }
 
 snapshots:
   '@bufbuild/protobuf@1.10.0': {}
@@ -1058,20 +1180,11 @@ snapshots:
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@livekit/mutex@1.1.1': {}
 
-  '@livekit/protocol@1.42.2':
+  '@livekit/protocol@1.46.6':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
@@ -1083,9 +1196,6 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.139.0': {}
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -1156,6 +1266,97 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1197,15 +1398,9 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  ansi-regex@5.0.1: {}
-
-  ansi-regex@6.0.1: {}
-
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  ansi-styles@6.2.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -1213,9 +1408,15 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
+  balanced-match@4.0.4: {}
+
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   call-bind@1.0.7:
     dependencies:
@@ -1248,12 +1449,6 @@ snapshots:
 
   corser@2.0.1: {}
 
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -1265,12 +1460,6 @@ snapshots:
       gopd: 1.1.0
 
   detect-libc@2.1.2: {}
-
-  eastasianwidth@0.2.0: {}
-
-  emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   es-define-property@1.0.0:
     dependencies:
@@ -1296,9 +1485,8 @@ snapshots:
 
   follow-redirects@1.15.9: {}
 
-  foreground-child@3.3.1:
+  foreground-child@4.0.3:
     dependencies:
-      cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
   fsevents@2.3.3:
@@ -1314,14 +1502,11 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
 
-  glob@11.0.0:
+  glob@13.0.6:
     dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.0.1
-      minimatch: 10.1.1
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.0
-      path-scurry: 2.0.0
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   gopd@1.1.0:
     dependencies:
@@ -1380,17 +1565,11 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  is-fullwidth-code-point@3.0.0: {}
-
-  isexe@2.0.0: {}
-
-  jackspeak@4.0.1:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-
   jose@6.1.3: {}
+
+  jsonc-simple-parser@3.0.0:
+    dependencies:
+      reghex: 3.0.2
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1441,19 +1620,18 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  livekit-client@2.16.1(@types/dom-mediacapture-record@1.0.22):
+  livekit-client@2.20.1(@types/dom-mediacapture-record@1.0.22):
     dependencies:
       '@livekit/mutex': 1.1.1
-      '@livekit/protocol': 1.42.2
+      '@livekit/protocol': 1.46.6
       '@types/dom-mediacapture-record': 1.0.22
       events: 3.3.0
       jose: 6.1.3
       loglevel: 1.9.2
       sdp-transform: 2.15.0
-      ts-debounce: 4.0.0
       tslib: 2.8.1
       typed-emitter: 2.1.0
-      webrtc-adapter: 9.0.1
+      webrtc-adapter: 9.0.6
 
   lodash@4.17.21: {}
 
@@ -1471,9 +1649,15 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
+
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   mkdirp@0.5.6:
     dependencies:
@@ -1491,14 +1675,17 @@ snapshots:
 
   opener@1.5.2: {}
 
-  package-json-from-dist@1.0.0: {}
-
-  path-key@3.1.1: {}
+  package-json-from-dist@1.0.1: {}
 
   path-scurry@2.0.0:
     dependencies:
       lru-cache: 11.0.0
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.0.0
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -1522,7 +1709,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier@3.7.4: {}
+  prettier@3.9.4: {}
 
   qs@6.13.1:
     dependencies:
@@ -1530,17 +1717,19 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  reghex@3.0.2: {}
+
   requires-port@1.0.0: {}
 
-  resolve-import@2.0.0:
+  resolve-import@2.4.0:
     dependencies:
-      glob: 11.0.0
+      glob: 13.0.6
       walk-up-path: 4.0.0
 
-  rimraf@6.0.1:
+  rimraf@6.1.3:
     dependencies:
-      glob: 11.0.0
-      package-json-from-dist: 1.0.0
+      glob: 13.0.6
+      package-json-from-dist: 1.0.1
 
   rolldown@1.1.5:
     dependencies:
@@ -1587,12 +1776,6 @@ snapshots:
       gopd: 1.1.0
       has-property-descriptors: 1.0.2
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
-
   side-channel@1.0.6:
     dependencies:
       call-bind: 1.0.7
@@ -1610,37 +1793,16 @@ snapshots:
 
   std-env@4.2.0: {}
 
-  string-width@4.2.3:
-    dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  strip-ansi@7.1.0:
-    dependencies:
-      ansi-regex: 6.0.1
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
-  sync-content@2.0.1:
+  sync-content@2.0.4:
     dependencies:
-      glob: 11.0.0
+      glob: 13.0.6
       mkdirp: 3.0.1
       path-scurry: 2.0.0
-      rimraf: 6.0.1
-      tshy: 3.1.0
+      rimraf: 6.1.3
 
   tinybench@2.9.0: {}
 
@@ -1653,20 +1815,20 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  ts-debounce@4.0.0: {}
-
-  tshy@3.1.0:
+  tshy@4.1.3:
     dependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260707.2
       chalk: 5.6.2
       chokidar: 4.0.3
-      foreground-child: 3.3.1
+      foreground-child: 4.0.3
+      jsonc-simple-parser: 3.0.0
       minimatch: 10.1.1
       mkdirp: 3.0.1
       polite-json: 5.0.0
-      resolve-import: 2.0.0
-      rimraf: 6.0.1
-      sync-content: 2.0.1
-      typescript: 5.9.3
+      resolve-import: 2.4.0
+      rimraf: 6.1.3
+      sync-content: 2.0.4
+      typescript: 6.0.3
       walk-up-path: 4.0.0
 
   tslib@2.8.1: {}
@@ -1675,7 +1837,30 @@ snapshots:
     optionalDependencies:
       rxjs: 7.8.1
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   union@0.5.0:
     dependencies:
@@ -1720,7 +1905,7 @@ snapshots:
 
   walk-up-path@4.0.0: {}
 
-  webrtc-adapter@9.0.1:
+  webrtc-adapter@9.0.6:
     dependencies:
       sdp: 3.2.0
 
@@ -1728,23 +1913,7 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
-
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -334,10 +334,13 @@ test('sendData routes messages over 1KB via the socket', async () => {
   expect(socket.sent.map((sent) => JSON.parse(sent))).toEqual([message]);
 });
 
-test('sendData requires a type field', async () => {
-  const { session } = await joinConnectedCall();
-  expect(() => session.sendData({ text: 'Hello' })).toThrow('type');
-});
+test.each([{ data: { text: 'Hello' } }, { data: null }, { data: undefined }])(
+  'sendData rejects data without a type field ($data)',
+  async ({ data }) => {
+    const { session } = await joinConnectedCall();
+    expect(() => session.sendData(data)).toThrow('type');
+  },
+);
 
 test.each([
   { name: 'small (room-bound)', message: { type: 'ping', timestamp: 1 } },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,19 @@
 import { DisconnectReason, RoomEvent } from 'livekit-client';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { UltravoxErrorEvent, UltravoxSession, UltravoxSessionStatus } from './index.js';
+import {
+  Medium,
+  Role,
+  TextMessagePlacement,
+  TextMessageUrgency,
+  Transcript,
+  UltravoxDataMessageEvent,
+  UltravoxErrorEvent,
+  UltravoxSession,
+  UltravoxSessionStatus,
+} from './index.js';
 
 const { FakeRoom, micTracks, micGate } = vi.hoisted(() => {
-  const micTracks: Array<{ stopped: boolean }> = [];
+  const micTracks: Array<{ stopped: boolean; muted: boolean; stop: () => void }> = [];
   /** When set, createLocalAudioTrack blocks on this, like a pending mic permission prompt. */
   const micGate: { current?: Promise<void> } = {};
   /** In-memory stand-in for a livekit-client Room. State strings match livekit's ConnectionState. */
@@ -12,7 +22,11 @@ const { FakeRoom, micTracks, micGate } = vi.hoisted(() => {
 
     state = 'disconnected';
     connectOptions: any;
-    localParticipant = { publishTrack: async () => {}, publishData: () => {} };
+    publishedData: Uint8Array[] = [];
+    localParticipant = {
+      publishTrack: async () => {},
+      publishData: (payload: Uint8Array, _opts: any) => this.publishedData.push(payload),
+    };
     remoteParticipants = new Map();
     private readonly handlers = new Map<string, Array<(...args: any[]) => void>>();
 
@@ -52,13 +66,18 @@ vi.mock('livekit-client', async (importOriginal) => ({
     await micGate.current;
     const track = {
       stopped: false,
+      muted: false,
       setAudioContext: () => {},
-      mute: () => {},
-      unmute: () => {},
+      mute: () => {
+        track.muted = true;
+      },
+      unmute: () => {
+        track.muted = false;
+      },
       stop: () => {
         track.stopped = true;
       },
-      mediaStream: undefined,
+      mediaStream: {},
     };
     micTracks.push(track);
     return track;
@@ -71,12 +90,15 @@ class FakeWebSocket {
   onmessage: ((event: { data: string }) => void) | null = null;
   onclose: ((event: { wasClean: boolean; code: number; reason: string }) => void) | null = null;
   closed = false;
+  sent: string[] = [];
 
   constructor(readonly url: string) {
     FakeWebSocket.instances.push(this);
   }
 
-  send(_message: string) {}
+  send(message: string) {
+    this.sent.push(message);
+  }
 
   close() {
     this.closed = true;
@@ -101,6 +123,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 /** Creates a session and drives it through the join handshake, capturing emitted events. */
@@ -122,13 +145,33 @@ async function joinCall(sessionOptions: ConstructorParameters<typeof UltravoxSes
   return { session, socket, room, errors, statuses };
 }
 
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+/** Delivers a data message to the session as if the server had sent it over the room's data channel. */
+function receiveDataMessage(room: InstanceType<typeof FakeRoom>, message: object) {
+  room.emit(RoomEvent.DataReceived, textEncoder.encode(JSON.stringify(message)));
+}
+
+/** Returns all data messages the session has published to the room, decoded. */
+function publishedMessages(room: InstanceType<typeof FakeRoom>): any[] {
+  return room.publishedData.map((payload) => JSON.parse(textDecoder.decode(payload)));
+}
+
+/** Like joinCall, but also brings the session to the LISTENING status. */
+async function joinConnectedCall() {
+  const call = await joinCall();
+  receiveDataMessage(call.room, { type: 'state', state: 'listening' });
+  return call;
+}
+
 test('passes rtcConfig through to the room connection', async () => {
   const rtcConfig: RTCConfiguration = { iceTransportPolicy: 'relay' };
   const { room } = await joinCall({ rtcConfig });
   expect(room.connectOptions).toEqual({ rtcConfig });
 });
 
-test('disconnects without an error when the socket closes normally', async () => {
+test('disconnects without an error when the server hangs up (normal socket close)', async () => {
   const { session, socket, errors, statuses } = await joinCall();
   socket.onclose!({ wasClean: true, code: 1000, reason: '' });
   await vi.waitFor(() => expect(session.status).toBe(UltravoxSessionStatus.DISCONNECTED));
@@ -202,4 +245,247 @@ test.each([
   await vi.waitFor(() => expect(session.status).toBe(UltravoxSessionStatus.DISCONNECTED));
   socket.onclose!({ wasClean: false, code: 1006, reason: '' }); // The socket death that follows is not a second error.
   expect(errors.map((error) => error.message)).toEqual([expect.stringContaining(expected)]);
+});
+
+test('reaches DISCONNECTED even when media teardown fails', async () => {
+  const { session, room } = await joinCall();
+  await vi.waitFor(() => expect(micTracks).toHaveLength(1));
+  micTracks[0]!.stop = () => {
+    throw new Error('stop failed');
+  };
+  room.disconnect = async () => {
+    throw new Error('disconnect failed');
+  };
+  await session.leaveCall();
+  expect(session.status).toBe(UltravoxSessionStatus.DISCONNECTED);
+});
+
+test('joinCall throws while already in a call', async () => {
+  const { session } = await joinCall();
+  expect(() => session.joinCall('wss://example.test/join2')).toThrow('Cannot join a new call');
+});
+
+test('sendText sends a user_text_message with the given urgency and placement', async () => {
+  const { session, room } = await joinConnectedCall();
+  session.sendText('Hello', { urgency: TextMessageUrgency.IMMEDIATE, placement: TextMessagePlacement.PREVIOUS_PAUSE });
+  expect(publishedMessages(room)).toEqual([
+    { type: 'user_text_message', text: 'Hello', urgency: 'immediate', placement: 'previous_pause' },
+  ]);
+});
+
+test('sendText defers urgency and placement to server defaults when omitted', async () => {
+  const { session, room } = await joinConnectedCall();
+  session.sendText('Hello');
+  expect(publishedMessages(room)).toEqual([{ type: 'user_text_message', text: 'Hello' }]);
+});
+
+test.each([
+  { deferResponse: true, urgency: 'later' },
+  { deferResponse: false, urgency: 'immediate' },
+])('sendText maps deprecated deferResponse=$deferResponse to urgency $urgency', async ({ deferResponse, urgency }) => {
+  const { session, room } = await joinConnectedCall();
+  session.sendText('Hello', deferResponse);
+  expect(publishedMessages(room)).toEqual([{ type: 'user_text_message', text: 'Hello', urgency }]);
+});
+
+test('sendText throws while not connected', async () => {
+  const { session } = await joinCall(); // No state message has arrived, so the session is still CONNECTING.
+  expect(() => session.sendText('Hello')).toThrow('Cannot send text');
+});
+
+test('setOutputMedium sends a set_output_medium message', async () => {
+  const { session, room } = await joinConnectedCall();
+  session.setOutputMedium(Medium.TEXT);
+  expect(publishedMessages(room)).toEqual([{ type: 'set_output_medium', medium: 'text' }]);
+});
+
+test('sendData routes messages over 1KB via the socket', async () => {
+  const { session, room, socket } = await joinConnectedCall();
+  const message = { type: 'user_text_message', text: 'a'.repeat(2000) };
+  session.sendData(message);
+  expect(publishedMessages(room)).toEqual([]);
+  expect(socket.sent.map((sent) => JSON.parse(sent))).toEqual([message]);
+});
+
+test('sendData requires a type field', async () => {
+  const { session } = await joinConnectedCall();
+  expect(() => session.sendData({ text: 'Hello' })).toThrow('type');
+});
+
+test('sendData throws after the call ends', async () => {
+  const { session } = await joinConnectedCall();
+  await session.leaveCall();
+  expect(() => session.sendData({ type: 'ping', timestamp: 1 })).toThrow('Cannot send data');
+});
+
+test('handles data messages arriving over the socket', async () => {
+  const { session, socket } = await joinCall();
+  socket.onmessage!({ data: JSON.stringify({ type: 'state', state: 'listening' }) });
+  expect(session.status).toBe(UltravoxSessionStatus.LISTENING);
+  expect(FakeRoom.instances).toHaveLength(1); // The message must not be treated as a second room_info.
+});
+
+test('state messages update the session status', async () => {
+  const { session, room, statuses } = await joinCall();
+  receiveDataMessage(room, { type: 'state', state: 'thinking' });
+  expect(session.status).toBe(UltravoxSessionStatus.THINKING);
+  expect(statuses).toEqual([UltravoxSessionStatus.CONNECTING, UltravoxSessionStatus.THINKING]);
+});
+
+test('transcript messages build the session transcripts', async () => {
+  const { session, room } = await joinConnectedCall();
+  let transcriptsEvents = 0;
+  session.addEventListener('transcripts', () => transcriptsEvents++);
+  const agentMessage = { type: 'transcript', role: 'agent', medium: 'voice', ordinal: 0, final: false };
+  receiveDataMessage(room, { ...agentMessage, delta: 'Hel' });
+  receiveDataMessage(room, { ...agentMessage, delta: 'lo' });
+  expect(session.transcripts).toEqual([new Transcript('Hello', false, Role.AGENT, Medium.VOICE, 0)]);
+  receiveDataMessage(room, { ...agentMessage, final: true, text: 'Hello!' });
+  receiveDataMessage(room, { type: 'transcript', role: 'user', medium: 'text', ordinal: 1, final: true, text: 'Hi' });
+  expect(session.transcripts).toEqual([
+    new Transcript('Hello!', true, Role.AGENT, Medium.VOICE, 0),
+    new Transcript('Hi', true, Role.USER, Medium.TEXT, 1),
+  ]);
+  expect(transcriptsEvents).toBe(4);
+});
+
+test('data_message events allow suppressing default handling', async () => {
+  const { session, room } = await joinConnectedCall();
+  const messages: any[] = [];
+  session.addEventListener('data_message', (event) => {
+    const dataMessageEvent = event as UltravoxDataMessageEvent;
+    messages.push(dataMessageEvent.message);
+    dataMessageEvent.preventDefault();
+  });
+  receiveDataMessage(room, { type: 'state', state: 'speaking' });
+  expect(messages).toEqual([{ type: 'state', state: 'speaking' }]);
+  expect(session.status).toBe(UltravoxSessionStatus.LISTENING); // Unchanged because default handling was suppressed.
+});
+
+test.each([
+  { name: 'a string result', result: 'ok', expected: { result: 'ok' } },
+  {
+    name: 'an object result',
+    result: { result: 'ok', responseType: 'hang-up', agentReaction: 'listens' },
+    expected: { result: 'ok', responseType: 'hang-up', agentReaction: 'listens' },
+  },
+  {
+    name: 'an invalid result',
+    result: 42,
+    expected: { errorType: 'implementation-error', errorMessage: expect.stringContaining('must be a string') },
+  },
+])('client tool invocations send a client_tool_result for $name', async ({ result, expected }) => {
+  const { room, session } = await joinConnectedCall();
+  const invocations: any[] = [];
+  session.registerToolImplementation('myTool', (async (parameters: any) => {
+    invocations.push(parameters);
+    return result;
+  }) as any);
+  receiveDataMessage(room, {
+    type: 'client_tool_invocation',
+    toolName: 'myTool',
+    invocationId: 'call_1',
+    parameters: { a: 1 },
+  });
+  await vi.waitFor(() =>
+    expect(publishedMessages(room)).toEqual([{ type: 'client_tool_result', invocationId: 'call_1', ...expected }]),
+  );
+  expect(invocations).toEqual([{ a: 1 }]);
+});
+
+test('client tool errors send an implementation-error result', async () => {
+  const { room, session } = await joinConnectedCall();
+  session.registerToolImplementation('myTool', () => {
+    throw new Error('boom');
+  });
+  receiveDataMessage(room, {
+    type: 'client_tool_invocation',
+    toolName: 'myTool',
+    invocationId: 'call_1',
+    parameters: {},
+  });
+  await vi.waitFor(() =>
+    expect(publishedMessages(room)).toEqual([
+      { type: 'client_tool_result', invocationId: 'call_1', errorType: 'implementation-error', errorMessage: 'boom' },
+    ]),
+  );
+});
+
+test('unregistered client tools send an undefined-error result', async () => {
+  const { room } = await joinConnectedCall();
+  receiveDataMessage(room, {
+    type: 'client_tool_invocation',
+    toolName: 'nope',
+    invocationId: 'call_1',
+    parameters: {},
+  });
+  expect(publishedMessages(room)).toEqual([
+    {
+      type: 'client_tool_result',
+      invocationId: 'call_1',
+      errorType: 'undefined',
+      errorMessage: expect.stringContaining('not registered'),
+    },
+  ]);
+});
+
+test('client tool results after the call ends are dropped without throwing', async () => {
+  const { room, session } = await joinConnectedCall();
+  let finishTool!: (result: string) => void;
+  session.registerToolImplementation('myTool', () => new Promise<string>((resolve) => (finishTool = resolve)));
+  receiveDataMessage(room, {
+    type: 'client_tool_invocation',
+    toolName: 'myTool',
+    invocationId: 'call_1',
+    parameters: {},
+  });
+  await session.leaveCall();
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  finishTool('ok');
+  await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+});
+
+test('mic mute is applied to the mic track', async () => {
+  const { session } = await joinCall();
+  await vi.waitFor(() => expect(micTracks).toHaveLength(1));
+  session.muteMic();
+  expect([session.isMicMuted, micTracks[0]!.muted]).toEqual([true, true]);
+  session.toggleMicMute();
+  expect([session.isMicMuted, micTracks[0]!.muted]).toEqual([false, false]);
+});
+
+test('muting before the mic track exists applies once it is created', async () => {
+  let grantMicPermission!: () => void;
+  micGate.current = new Promise<void>((resolve) => (grantMicPermission = resolve));
+  const { session } = await joinCall();
+  session.muteMic();
+  grantMicPermission();
+  await vi.waitFor(() => expect(micTracks.map((track) => track.muted)).toEqual([true]));
+});
+
+test('speaker mute disables remote audio publications', async () => {
+  const { session, room } = await joinConnectedCall();
+  const enabledChanges: boolean[] = [];
+  const publication = { setEnabled: (value: boolean) => enabledChanges.push(value) };
+  room.remoteParticipants.set('agent', { audioTrackPublications: new Map([['pub', publication]]) });
+  session.muteSpeaker();
+  expect(session.isSpeakerMuted).toBe(true);
+  session.unmuteSpeaker();
+  expect(session.isSpeakerMuted).toBe(false);
+  expect(enabledChanges).toEqual([false, true]);
+});
+
+test('exposes mic and agent audio source nodes while audio is flowing', async () => {
+  const { session, room } = await joinCall();
+  expect(session.agentSourceNode).toBeUndefined();
+  await vi.waitFor(() => expect(session.micSourceNode).toBeDefined());
+  expect(session.micSourceNode).toBe(session.micSourceNode); // The node is stable across accesses.
+  room.emit(
+    RoomEvent.TrackSubscribed,
+    { kind: 'audio', attach: () => {}, mediaStream: {} },
+    { kind: 'audio', setEnabled: () => {} },
+  );
+  expect(session.agentSourceNode).toBeDefined();
+  await session.leaveCall();
+  expect([session.micSourceNode, session.agentSourceNode]).toEqual([undefined, undefined]);
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -362,6 +362,16 @@ test('sendData warns and drops messages before the room exists, regardless of me
   expect(FakeWebSocket.instances[FakeWebSocket.instances.length - 1]!.sent).toEqual([]);
 });
 
+test('data messages arriving after the call ends are ignored', async () => {
+  const { session, room } = await joinConnectedCall();
+  await session.leaveCall();
+  const messages: any[] = [];
+  session.addEventListener('data_message', (event) => messages.push((event as UltravoxDataMessageEvent).message));
+  receiveDataMessage(room, { type: 'state', state: 'listening' });
+  expect(session.status).toBe(UltravoxSessionStatus.DISCONNECTED);
+  expect(messages).toEqual([]);
+});
+
 test('handles data messages arriving over the socket', async () => {
   const { session, socket } = await joinCall();
   socket.onmessage!({ data: JSON.stringify({ type: 'state', state: 'listening' }) });
@@ -572,7 +582,10 @@ test('a session can be reused for a new call with fresh transcripts', async () =
   const { session, room } = await joinConnectedCall();
   receiveDataMessage(room, { type: 'transcript', role: 'user', medium: 'text', ordinal: 0, final: true, text: 'Hi' });
   await session.leaveCall();
+  let transcriptsEvents = 0;
+  session.addEventListener('transcripts', () => transcriptsEvents++);
   session.joinCall('wss://example.test/join');
+  expect(transcriptsEvents).toBe(1); // Listeners must be told the old call's transcripts were cleared.
   const socket = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]!;
   socket.onmessage!({ data: JSON.stringify({ roomUrl: 'wss://room.example.test', token: 'token' }) });
   await vi.waitFor(() => expect(FakeRoom.instances[FakeRoom.instances.length - 1]?.state).toBe('connected'));

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,7 +13,7 @@ import {
 } from './index.js';
 
 const { FakeRoom, micTracks, micGate } = vi.hoisted(() => {
-  const micTracks: Array<{ stopped: boolean; muted: boolean; stop: () => void }> = [];
+  const micTracks: Array<{ stopped: boolean; muted: boolean; stop: () => void; mediaStreamTrack: object }> = [];
   /** When set, createLocalAudioTrack blocks on this, like a pending mic permission prompt. */
   const micGate: { current?: Promise<void> } = {};
   /** In-memory stand-in for a livekit-client Room. State strings match livekit's ConnectionState. */
@@ -22,10 +22,10 @@ const { FakeRoom, micTracks, micGate } = vi.hoisted(() => {
 
     state = 'disconnected';
     connectOptions: any;
-    publishedData: Uint8Array[] = [];
+    publishedData: Array<{ payload: Uint8Array; opts: any }> = [];
     localParticipant = {
       publishTrack: async () => {},
-      publishData: (payload: Uint8Array, _opts: any) => this.publishedData.push(payload),
+      publishData: (payload: Uint8Array, opts: any) => this.publishedData.push({ payload, opts }),
     };
     remoteParticipants = new Map();
     private readonly handlers = new Map<string, Array<(...args: any[]) => void>>();
@@ -77,7 +77,7 @@ vi.mock('livekit-client', async (importOriginal) => ({
       stop: () => {
         track.stopped = true;
       },
-      mediaStream: {},
+      mediaStreamTrack: {},
     };
     micTracks.push(track);
     return track;
@@ -119,6 +119,12 @@ beforeEach(() => {
       pause() {}
     },
   );
+  vi.stubGlobal(
+    'MediaStream',
+    class {
+      constructor(readonly tracks: unknown[]) {}
+    },
+  );
 });
 
 afterEach(() => {
@@ -128,9 +134,20 @@ afterEach(() => {
 
 /** Creates a session and drives it through the join handshake, capturing emitted events. */
 async function joinCall(sessionOptions: ConstructorParameters<typeof UltravoxSession>[0] = {}) {
+  const sourceNodes: Array<{ stream: { tracks: unknown[] }; disconnected: boolean }> = [];
   const audioContext = {
     resume: () => {},
-    createMediaStreamSource: () => ({ disconnect: () => {} }),
+    createMediaStreamSource: (stream: { tracks: unknown[] }) => {
+      const node = {
+        stream,
+        disconnected: false,
+        disconnect: () => {
+          node.disconnected = true;
+        },
+      };
+      sourceNodes.push(node);
+      return node;
+    },
   } as unknown as AudioContext;
   const session = new UltravoxSession({ audioContext, ...sessionOptions });
   const errors: Error[] = [];
@@ -142,7 +159,7 @@ async function joinCall(sessionOptions: ConstructorParameters<typeof UltravoxSes
   socket.onmessage!({ data: JSON.stringify({ roomUrl: 'wss://room.example.test', token: 'token' }) });
   await vi.waitFor(() => expect(FakeRoom.instances[FakeRoom.instances.length - 1]?.state).toBe('connected'));
   const room = FakeRoom.instances[FakeRoom.instances.length - 1]!;
-  return { session, socket, room, errors, statuses };
+  return { session, socket, room, errors, statuses, sourceNodes };
 }
 
 const textEncoder = new TextEncoder();
@@ -155,7 +172,7 @@ function receiveDataMessage(room: InstanceType<typeof FakeRoom>, message: object
 
 /** Returns all data messages the session has published to the room, decoded. */
 function publishedMessages(room: InstanceType<typeof FakeRoom>): any[] {
-  return room.publishedData.map((payload) => JSON.parse(textDecoder.decode(payload)));
+  return room.publishedData.map((entry) => JSON.parse(textDecoder.decode(entry.payload)));
 }
 
 /** Like joinCall, but also brings the session to the LISTENING status. */
@@ -265,12 +282,22 @@ test('joinCall throws while already in a call', async () => {
   expect(() => session.joinCall('wss://example.test/join2')).toThrow('Cannot join a new call');
 });
 
-test('sendText sends a user_text_message with the given urgency and placement', async () => {
+test.each([
+  {
+    urgency: TextMessageUrgency.IMMEDIATE,
+    placement: TextMessagePlacement.PREVIOUS_PAUSE,
+    expected: { urgency: 'immediate', placement: 'previous_pause' },
+  },
+  {
+    urgency: TextMessageUrgency.SOON,
+    placement: TextMessagePlacement.BEFORE,
+    expected: { urgency: 'soon', placement: 'before' },
+  },
+])('sendText sends a user_text_message with urgency $expected.urgency', async ({ urgency, placement, expected }) => {
   const { session, room } = await joinConnectedCall();
-  session.sendText('Hello', { urgency: TextMessageUrgency.IMMEDIATE, placement: TextMessagePlacement.PREVIOUS_PAUSE });
-  expect(publishedMessages(room)).toEqual([
-    { type: 'user_text_message', text: 'Hello', urgency: 'immediate', placement: 'previous_pause' },
-  ]);
+  session.sendText('Hello', { urgency, placement });
+  expect(publishedMessages(room)).toEqual([{ type: 'user_text_message', text: 'Hello', ...expected }]);
+  expect(room.publishedData.map((entry) => entry.opts)).toEqual([{ reliable: true }]);
 });
 
 test('sendText defers urgency and placement to server defaults when omitted', async () => {
@@ -312,9 +339,19 @@ test('sendData requires a type field', async () => {
   expect(() => session.sendData({ text: 'Hello' })).toThrow('type');
 });
 
-test('sendData throws after the call ends', async () => {
+test.each([
+  { name: 'small (room-bound)', message: { type: 'ping', timestamp: 1 } },
+  { name: 'large (socket-bound)', message: { type: 'user_text_message', text: 'a'.repeat(2000) } },
+])('sendData throws after the call ends for $name messages', async ({ message }) => {
   const { session } = await joinConnectedCall();
   await session.leaveCall();
+  expect(() => session.sendData(message)).toThrow('Cannot send data');
+});
+
+test('sendData throws before the room exists, regardless of message size', async () => {
+  const session = new UltravoxSession({ audioContext: {} as AudioContext });
+  session.joinCall('wss://example.test/join'); // The socket exists now, but room_info hasn't arrived.
+  expect(() => session.sendData({ type: 'user_text_message', text: 'a'.repeat(2000) })).toThrow('Cannot send data');
   expect(() => session.sendData({ type: 'ping', timestamp: 1 })).toThrow('Cannot send data');
 });
 
@@ -476,16 +513,71 @@ test('speaker mute disables remote audio publications', async () => {
 });
 
 test('exposes mic and agent audio source nodes while audio is flowing', async () => {
-  const { session, room } = await joinCall();
+  const { session, room, sourceNodes } = await joinCall();
   expect(session.agentSourceNode).toBeUndefined();
   await vi.waitFor(() => expect(session.micSourceNode).toBeDefined());
   expect(session.micSourceNode).toBe(session.micSourceNode); // The node is stable across accesses.
-  room.emit(
-    RoomEvent.TrackSubscribed,
-    { kind: 'audio', attach: () => {}, mediaStream: {} },
-    { kind: 'audio', setEnabled: () => {} },
-  );
+  const agentTrack = { kind: 'audio', attach: () => {}, mediaStreamTrack: {} };
+  room.emit(RoomEvent.TrackSubscribed, agentTrack, { kind: 'audio', setEnabled: () => {} });
   expect(session.agentSourceNode).toBeDefined();
+  // Each node must be built from the corresponding track's stream.
+  expect(sourceNodes.map((node) => node.stream.tracks)).toEqual([
+    [micTracks[0]!.mediaStreamTrack],
+    [agentTrack.mediaStreamTrack],
+  ]);
   await session.leaveCall();
   expect([session.micSourceNode, session.agentSourceNode]).toEqual([undefined, undefined]);
+  expect(sourceNodes.map((node) => node.disconnected)).toEqual([true, true]);
+});
+
+test('recreates the agent source node when a new agent track arrives (e.g. after a media reconnect)', async () => {
+  const { session, room } = await joinCall();
+  const subscribeAgentTrack = (track: object) =>
+    room.emit(RoomEvent.TrackSubscribed, track, { kind: 'audio', setEnabled: () => {} });
+  const firstTrack = { kind: 'audio', attach: () => {}, mediaStreamTrack: {} };
+  subscribeAgentTrack(firstTrack);
+  const firstNode = session.agentSourceNode;
+  subscribeAgentTrack(firstTrack); // Resubscribing the same track must not invalidate the node.
+  expect(session.agentSourceNode).toBe(firstNode);
+  subscribeAgentTrack({ kind: 'audio', attach: () => {}, mediaStreamTrack: {} });
+  expect(session.agentSourceNode).not.toBe(firstNode);
+  expect((firstNode as any).disconnected).toBe(true);
+});
+
+test('tolerates blocked audio autoplay during join', async () => {
+  vi.stubGlobal(
+    'Audio',
+    class {
+      srcObject: unknown = null;
+      play() {
+        return Promise.reject(new Error('autoplay blocked'));
+      }
+      pause() {}
+    },
+  );
+  const audioContext = { resume: () => Promise.reject(new Error('autoplay blocked')) } as unknown as AudioContext;
+  const { session, room } = await joinCall({ audioContext });
+  receiveDataMessage(room, { type: 'state', state: 'listening' });
+  expect(session.status).toBe(UltravoxSessionStatus.LISTENING);
+});
+
+test('a session can be reused for a new call with fresh transcripts', async () => {
+  const { session, room } = await joinConnectedCall();
+  receiveDataMessage(room, { type: 'transcript', role: 'user', medium: 'text', ordinal: 0, final: true, text: 'Hi' });
+  await session.leaveCall();
+  session.joinCall('wss://example.test/join');
+  const socket = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]!;
+  socket.onmessage!({ data: JSON.stringify({ roomUrl: 'wss://room.example.test', token: 'token' }) });
+  await vi.waitFor(() => expect(FakeRoom.instances[FakeRoom.instances.length - 1]?.state).toBe('connected'));
+  const secondRoom = FakeRoom.instances[FakeRoom.instances.length - 1]!;
+  expect(session.transcripts).toEqual([]);
+  receiveDataMessage(secondRoom, {
+    type: 'transcript',
+    role: 'agent',
+    medium: 'voice',
+    ordinal: 0,
+    final: true,
+    text: 'Hey',
+  });
+  expect(session.transcripts).toEqual([new Transcript('Hey', true, Role.AGENT, Medium.VOICE, 0)]);
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -365,6 +365,16 @@ test('sendData warns and drops messages before the room exists, regardless of me
   expect(FakeWebSocket.instances[FakeWebSocket.instances.length - 1]!.sent).toEqual([]);
 });
 
+test('room_info arriving after the call ends does not start a room or request the mic', async () => {
+  const session = new UltravoxSession({ audioContext: {} as AudioContext });
+  session.joinCall('wss://example.test/join');
+  await session.leaveCall();
+  const socket = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]!;
+  socket.onmessage!({ data: JSON.stringify({ roomUrl: 'wss://room.example.test', token: 'token' }) });
+  expect(FakeRoom.instances).toEqual([]);
+  expect(micTracks).toEqual([]);
+});
+
 test('data messages arriving after the call ends are ignored', async () => {
   const { session, room } = await joinConnectedCall();
   await session.leaveCall();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -342,17 +342,24 @@ test('sendData requires a type field', async () => {
 test.each([
   { name: 'small (room-bound)', message: { type: 'ping', timestamp: 1 } },
   { name: 'large (socket-bound)', message: { type: 'user_text_message', text: 'a'.repeat(2000) } },
-])('sendData throws after the call ends for $name messages', async ({ message }) => {
-  const { session } = await joinConnectedCall();
+])('sendData warns and drops $name messages after the call ends', async ({ message }) => {
+  const { session, socket, room } = await joinConnectedCall();
   await session.leaveCall();
-  expect(() => session.sendData(message)).toThrow('Cannot send data');
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  session.sendData(message);
+  expect(warn).toHaveBeenCalledTimes(1);
+  expect(publishedMessages(room)).toEqual([]);
+  expect(socket.sent).toEqual([]);
 });
 
-test('sendData throws before the room exists, regardless of message size', async () => {
+test('sendData warns and drops messages before the room exists, regardless of message size', async () => {
   const session = new UltravoxSession({ audioContext: {} as AudioContext });
   session.joinCall('wss://example.test/join'); // The socket exists now, but room_info hasn't arrived.
-  expect(() => session.sendData({ type: 'user_text_message', text: 'a'.repeat(2000) })).toThrow('Cannot send data');
-  expect(() => session.sendData({ type: 'ping', timestamp: 1 })).toThrow('Cannot send data');
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  session.sendData({ type: 'user_text_message', text: 'a'.repeat(2000) });
+  session.sendData({ type: 'ping', timestamp: 1 });
+  expect(warn).toHaveBeenCalledTimes(2);
+  expect(FakeWebSocket.instances[FakeWebSocket.instances.length - 1]!.sent).toEqual([]);
 });
 
 test('handles data messages arriving over the socket', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,8 +247,11 @@ export class UltravoxSession extends EventTarget {
    * typically shortly after the call connects (or after the user grants mic permission).
    */
   get micSourceNode(): MediaStreamAudioSourceNode | undefined {
-    if (!this._micSourceNode && this.localAudioTrack?.mediaStream) {
-      this._micSourceNode = this.audioContext.createMediaStreamSource(this.localAudioTrack.mediaStream);
+    // Built from mediaStreamTrack rather than the track's mediaStream because the latter is
+    // internal to livekit-client.
+    const track = this.localAudioTrack?.mediaStreamTrack;
+    if (!this._micSourceNode && track) {
+      this._micSourceNode = this.audioContext.createMediaStreamSource(new MediaStream([track]));
     }
     return this._micSourceNode;
   }
@@ -260,8 +263,9 @@ export class UltravoxSession extends EventTarget {
    * shortly after the call connects.
    */
   get agentSourceNode(): MediaStreamAudioSourceNode | undefined {
-    if (!this._agentSourceNode && this.agentAudioTrack?.mediaStream) {
-      this._agentSourceNode = this.audioContext.createMediaStreamSource(this.agentAudioTrack.mediaStream);
+    const track = this.agentAudioTrack?.mediaStreamTrack;
+    if (!this._agentSourceNode && track) {
+      this._agentSourceNode = this.audioContext.createMediaStreamSource(new MediaStream([track]));
     }
     return this._agentSourceNode;
   }
@@ -289,6 +293,8 @@ export class UltravoxSession extends EventTarget {
     if (this._status !== UltravoxSessionStatus.DISCONNECTED) {
       throw new Error('Cannot join a new call while already in a call');
     }
+    // Clear any previous call's transcripts in case this session instance is being reused.
+    this._transcripts.length = 0;
     const url = new URL(joinUrl);
     let uvClientVersion = `web_${ULTRAVOX_SDK_VERSION}`;
     if (clientVersion) {
@@ -351,18 +357,18 @@ export class UltravoxSession extends EventTarget {
     if (obj.type == undefined) {
       throw new Error('Data must have a type field');
     }
+    // The socket exists from joinCall on and the room exists from the server's room_info
+    // response on, so requiring both keeps behavior independent of which transport the size
+    // check below happens to pick.
+    if (!this.room || !this.socket) {
+      throw new Error(`Cannot send data while not connected. Current status is ${this._status}.`);
+    }
     const msgStr = JSON.stringify(obj);
     const msgBytes = this.textEncoder.encode(msgStr);
     if (msgBytes.length > 1024) {
       // Messages that could exceed the WebRTC data channel's practical size limit go via websocket.
-      if (!this.socket) {
-        throw new Error(`Cannot send data while not connected. Current status is ${this._status}.`);
-      }
       this.socket.send(msgStr);
     } else {
-      if (!this.room) {
-        throw new Error(`Cannot send data while not connected. Current status is ${this._status}.`);
-      }
       this.room.localParticipant.publishData(msgBytes, { reliable: true });
     }
   }
@@ -549,6 +555,12 @@ export class UltravoxSession extends EventTarget {
     } else if (track.kind === 'audio') {
       const audioTrack = track as RemoteAudioTrack;
       audioTrack.attach(this.audioElement);
+      if (this.agentAudioTrack !== audioTrack) {
+        // A new track (e.g. after a full media reconnect) means a cached source node is bound
+        // to a dead stream, so it must be recreated on next access.
+        this._agentSourceNode?.disconnect();
+        this._agentSourceNode = undefined;
+      }
       this.agentAudioTrack = audioTrack;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -362,7 +362,7 @@ export class UltravoxSession extends EventTarget {
    * after it ends), the message is dropped with a console warning.
    */
   sendData(obj: any) {
-    if (obj.type == undefined) {
+    if (obj?.type == undefined) {
       throw new Error('Data must have a type field');
     }
     // The socket exists from joinCall on and the room exists from the server's room_info

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,8 +293,12 @@ export class UltravoxSession extends EventTarget {
     if (this._status !== UltravoxSessionStatus.DISCONNECTED) {
       throw new Error('Cannot join a new call while already in a call');
     }
-    // Clear any previous call's transcripts in case this session instance is being reused.
-    this._transcripts.length = 0;
+    // Clear any previous call's transcripts in case this session instance is being reused,
+    // notifying listeners that may be rendering them.
+    if (this._transcripts.length > 0) {
+      this._transcripts.length = 0;
+      this.dispatchEvent(new UltravoxTranscriptsChangedEvent());
+    }
     const url = new URL(joinUrl);
     let uvClientVersion = `web_${ULTRAVOX_SDK_VERSION}`;
     if (clientVersion) {
@@ -354,8 +358,8 @@ export class UltravoxSession extends EventTarget {
 
   /**
    * Sends an arbitrary data message to the server. See https://docs.ultravox.ai/datamessages
-   * for message types. If the session is not connected, the message is dropped with a console
-   * warning.
+   * for message types. If the call's transports are unavailable (before the call is joined or
+   * after it ends), the message is dropped with a console warning.
    */
   sendData(obj: any) {
     if (obj.type == undefined) {
@@ -585,6 +589,11 @@ export class UltravoxSession extends EventTarget {
   }
 
   private handleDataMessage(msg: any) {
+    if (this.isStopped()) {
+      // Late messages can still be delivered while teardown is in flight (room.disconnect is
+      // async), and must not resurrect the session by mutating its status or transcripts.
+      return;
+    }
     const runDefault = this.dispatchEvent(new UltravoxDataMessageEvent(msg));
     if (runDefault) {
       if (msg.type === 'state') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -435,6 +435,12 @@ export class UltravoxSession extends EventTarget {
   }
 
   private async handleSocketMessage(event: MessageEvent) {
+    if (this.isStopped()) {
+      // A message already queued when leaveCall closed the socket can still be dispatched. If
+      // it were the room_info message, proceeding would prompt for mic permission and connect
+      // a room that teardown (already finished) would never disconnect.
+      return;
+    }
     const msg = JSON.parse(event.data);
     if (this.room) {
       // The first socket message contains room info. The server sends nothing else over the

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,30 @@ export enum Medium {
   TEXT = 'text',
 }
 
+/* How soon the agent should respond to a message sent via sendText. */
+export enum TextMessageUrgency {
+  /* Start a new response immediately, even if the agent is speaking. */
+  IMMEDIATE = 'immediate',
+  /* Don't interrupt the agent, but respond at the next opportunity. This is the default. */
+  SOON = 'soon',
+  /* Don't force a response. The message will be considered whenever the agent next responds. */
+  LATER = 'later',
+}
+
+/* Where a message sent via sendText should be placed if the user is speaking when it is received. */
+export enum TextMessagePlacement {
+  /* Place the message before any active (i.e. not-yet-responded-to) user speech. This is the default. */
+  BEFORE = 'before',
+  /* Place the message after the most recent pause in active user speech. */
+  PREVIOUS_PAUSE = 'previous_pause',
+}
+
+/* Options for messages sent via sendText. */
+export interface SendTextOptions {
+  urgency?: TextMessageUrgency;
+  placement?: TextMessagePlacement;
+}
+
 /* How the agent should proceed after a tool invocation. */
 export enum AgentReaction {
   /* The agent should speak after the tool invocation. This is the default and is recommended for tools that retrieve information for the agent to act on. */
@@ -129,7 +153,10 @@ export type ClientToolImplementation = (parameters: {
  *
  * - status: The status of the session has changed.
  * - transcripts: A transcript was added or updated.
- * - experimental_message: An experimental message was received. The message is included in the event.
+ * - data_message: A data message was received. The message is included in the event, and calling
+ *   preventDefault() on the event suppresses this SDK's default handling of the message.
+ * - error: The session ended unexpectedly. The error is included in the event.
+ * - video_track_subscribed: The agent published a video track. The video element is included in the event.
  *
  */
 export class UltravoxSession extends EventTarget {
@@ -148,7 +175,9 @@ export class UltravoxSession extends EventTarget {
   private videoElement?: HTMLVideoElement;
   private audioElement = new Audio();
   private localAudioTrack?: LocalAudioTrack;
-  private micSourceNode?: MediaStreamAudioSourceNode;
+  private agentAudioTrack?: RemoteAudioTrack;
+  private _micSourceNode?: MediaStreamAudioSourceNode;
+  private _agentSourceNode?: MediaStreamAudioSourceNode;
   private readonly textDecoder = new TextDecoder();
   private readonly textEncoder = new TextEncoder();
 
@@ -212,6 +241,32 @@ export class UltravoxSession extends EventTarget {
   }
 
   /**
+   * An AudioNode producing the user's (microphone) audio, for example for attaching an
+   * AnalyserNode to drive a speech indicator. The node belongs to the session's AudioContext
+   * (which can be provided to the constructor). Undefined until the call's mic audio exists,
+   * typically shortly after the call connects (or after the user grants mic permission).
+   */
+  get micSourceNode(): MediaStreamAudioSourceNode | undefined {
+    if (!this._micSourceNode && this.localAudioTrack?.mediaStream) {
+      this._micSourceNode = this.audioContext.createMediaStreamSource(this.localAudioTrack.mediaStream);
+    }
+    return this._micSourceNode;
+  }
+
+  /**
+   * An AudioNode producing the agent's audio, for example for attaching an AnalyserNode to
+   * drive a speech indicator. The node belongs to the session's AudioContext (which can be
+   * provided to the constructor). Undefined until the call's agent audio exists, typically
+   * shortly after the call connects.
+   */
+  get agentSourceNode(): MediaStreamAudioSourceNode | undefined {
+    if (!this._agentSourceNode && this.agentAudioTrack?.mediaStream) {
+      this._agentSourceNode = this.audioContext.createMediaStreamSource(this.agentAudioTrack.mediaStream);
+    }
+    return this._agentSourceNode;
+  }
+
+  /**
    * Registers a client tool implementation with the given name. If the call is
    * started with a client-implemented tool, this implementation will be invoked
    * when the model calls the tool.
@@ -267,12 +322,28 @@ export class UltravoxSession extends EventTarget {
     this.sendData({ type: 'set_output_medium', medium });
   }
 
-  /** Sends a message via text. */
-  sendText(text: string, deferResponse?: boolean) {
+  /**
+   * Sends a user message via text. When omitted, urgency defaults to SOON and placement to
+   * BEFORE (applied server-side).
+   */
+  sendText(text: string, options?: SendTextOptions): void;
+  /** @deprecated Use SendTextOptions instead. deferResponse maps to urgency LATER (true) or IMMEDIATE (false). */
+  sendText(text: string, deferResponse?: boolean): void;
+  sendText(text: string, optionsOrDeferResponse?: SendTextOptions | boolean) {
     if (!UltravoxSession.CONNECTED_STATUSES.has(this._status)) {
       throw new Error(`Cannot send text while not connected. Current status is ${this._status}.`);
     }
-    this.sendData({ type: 'input_text_message', text, deferResponse });
+    if (typeof optionsOrDeferResponse === 'boolean') {
+      const urgency = optionsOrDeferResponse ? TextMessageUrgency.LATER : TextMessageUrgency.IMMEDIATE;
+      this.sendData({ type: 'user_text_message', text, urgency });
+      return;
+    }
+    this.sendData({
+      type: 'user_text_message',
+      text,
+      urgency: optionsOrDeferResponse?.urgency,
+      placement: optionsOrDeferResponse?.placement,
+    });
   }
 
   /* Sends an arbitrary data message to the server. See https://docs.ultravox.ai/datamessages for message types. */
@@ -283,9 +354,16 @@ export class UltravoxSession extends EventTarget {
     const msgStr = JSON.stringify(obj);
     const msgBytes = this.textEncoder.encode(msgStr);
     if (msgBytes.length > 1024) {
-      this.socket?.send(msgStr);
+      // Messages that could exceed the WebRTC data channel's practical size limit go via websocket.
+      if (!this.socket) {
+        throw new Error(`Cannot send data while not connected. Current status is ${this._status}.`);
+      }
+      this.socket.send(msgStr);
     } else {
-      this.room?.localParticipant.publishData(msgBytes, { reliable: true });
+      if (!this.room) {
+        throw new Error(`Cannot send data while not connected. Current status is ${this._status}.`);
+      }
+      this.room.localParticipant.publishData(msgBytes, { reliable: true });
     }
   }
 
@@ -341,6 +419,13 @@ export class UltravoxSession extends EventTarget {
 
   private async handleSocketMessage(event: MessageEvent) {
     const msg = JSON.parse(event.data);
+    if (this.room) {
+      // The first socket message contains room info. The server sends nothing else over the
+      // socket today, but any later message would be an ordinary data message (mirroring how
+      // this client sends its large data messages over the socket).
+      this.handleDataMessage(msg);
+      return;
+    }
     this.room = new Room({ webAudioMix: false });
     this.room.on(RoomEvent.TrackSubscribed, (_track, publication) => {
       if (publication.kind == Track.Kind.Audio) {
@@ -353,8 +438,11 @@ export class UltravoxSession extends EventTarget {
     );
     this.room.on(RoomEvent.Disconnected, (reason?: DisconnectReason) => this.handleRoomDisconnected(reason));
 
-    this.audioContext.resume();
-    this.audioElement.play();
+    // Both calls reject if the browser is blocking audio pending a user gesture. Audio will
+    // remain blocked until the integrator resumes it after a gesture, but that's not fatal to
+    // the call itself (and is the integrator's responsibility to avoid or handle).
+    this.audioContext.resume()?.catch(() => {});
+    this.audioElement.play()?.catch(() => {});
 
     const [track, _] = await Promise.all([
       createLocalAudioTrack(),
@@ -370,9 +458,6 @@ export class UltravoxSession extends EventTarget {
     this.localAudioTrack.setAudioContext(this.audioContext);
     if (this.isMicMuted) {
       this.localAudioTrack.mute();
-    }
-    if (this.localAudioTrack.mediaStream) {
-      this.micSourceNode = this.audioContext.createMediaStreamSource(this.localAudioTrack.mediaStream);
     }
 
     const opts = { name: 'audio', simulcast: false, source: Track.Source.Microphone };
@@ -431,14 +516,23 @@ export class UltravoxSession extends EventTarget {
 
   private async performDisconnect() {
     this.setStatus(UltravoxSessionStatus.DISCONNECTING);
-    this.localAudioTrack?.stop();
+    // A failure to tear down one resource must not prevent tearing down the others (or leave
+    // the session stuck short of DISCONNECTED), so the fallible steps are individually guarded.
+    try {
+      this.localAudioTrack?.stop();
+    } catch {}
     this.localAudioTrack = undefined;
-    await this.room?.disconnect();
+    try {
+      await this.room?.disconnect();
+    } catch {}
     this.room = undefined;
     this.socket?.close();
     this.socket = undefined;
-    this.micSourceNode?.disconnect();
-    this.micSourceNode = undefined;
+    this._micSourceNode?.disconnect();
+    this._micSourceNode = undefined;
+    this._agentSourceNode?.disconnect();
+    this._agentSourceNode = undefined;
+    this.agentAudioTrack = undefined;
     this.videoElement?.pause();
     this.audioElement.pause();
     this.audioElement.srcObject = null;
@@ -455,6 +549,7 @@ export class UltravoxSession extends EventTarget {
     } else if (track.kind === 'audio') {
       const audioTrack = track as RemoteAudioTrack;
       audioTrack.attach(this.audioElement);
+      this.agentAudioTrack = audioTrack;
     }
   }
 
@@ -467,7 +562,10 @@ export class UltravoxSession extends EventTarget {
   }
 
   private handleDataReceived(payload: Uint8Array, _participant: any) {
-    const msg = JSON.parse(this.textDecoder.decode(payload));
+    this.handleDataMessage(JSON.parse(this.textDecoder.decode(payload)));
+  }
+
+  private handleDataMessage(msg: any) {
     const runDefault = this.dispatchEvent(new UltravoxDataMessageEvent(msg));
     if (runDefault) {
       if (msg.type === 'state') {
@@ -511,7 +609,7 @@ export class UltravoxSession extends EventTarget {
   private invokeClientTool(toolName: string, invocationId: string, parameters: { [key: string]: any }) {
     const tool = this.registeredTools.get(toolName);
     if (!tool) {
-      this.sendData({
+      this.sendClientToolResult({
         type: 'client_tool_result',
         invocationId,
         errorType: 'undefined',
@@ -536,9 +634,9 @@ export class UltravoxSession extends EventTarget {
 
   private handleClientToolResult(invocationId: string, result: any) {
     if (typeof result === 'string') {
-      this.sendData({ type: 'client_tool_result', invocationId, result });
+      this.sendClientToolResult({ type: 'client_tool_result', invocationId, result });
     } else if (typeof result.result !== 'string' || typeof result.responseType !== 'string') {
-      this.sendData({
+      this.sendClientToolResult({
         type: 'client_tool_result',
         invocationId,
         errorType: 'implementation-error',
@@ -546,7 +644,7 @@ export class UltravoxSession extends EventTarget {
           'Client tool result must be a string or an object with string "result" and "responseType" properties.',
       });
     } else {
-      this.sendData({
+      this.sendClientToolResult({
         type: 'client_tool_result',
         invocationId,
         ...result,
@@ -555,11 +653,20 @@ export class UltravoxSession extends EventTarget {
   }
 
   private handleClientToolFailure(invocationId: string, error: any) {
-    this.sendData({
+    this.sendClientToolResult({
       type: 'client_tool_result',
       invocationId,
       errorType: 'implementation-error',
       errorMessage: error instanceof Error ? error.message : undefined,
     });
+  }
+
+  private sendClientToolResult(resultMessage: any) {
+    try {
+      this.sendData(resultMessage);
+    } catch (e) {
+      // The call likely ended while the tool was running, so no one can receive the result.
+      console.warn('Failed to send client tool result:', e);
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -352,16 +352,23 @@ export class UltravoxSession extends EventTarget {
     });
   }
 
-  /* Sends an arbitrary data message to the server. See https://docs.ultravox.ai/datamessages for message types. */
+  /**
+   * Sends an arbitrary data message to the server. See https://docs.ultravox.ai/datamessages
+   * for message types. If the session is not connected, the message is dropped with a console
+   * warning.
+   */
   sendData(obj: any) {
     if (obj.type == undefined) {
       throw new Error('Data must have a type field');
     }
     // The socket exists from joinCall on and the room exists from the server's room_info
     // response on, so requiring both keeps behavior independent of which transport the size
-    // check below happens to pick.
+    // check below happens to pick. Undeliverable messages warn rather than throw: the loss is
+    // typically visible through other means (call events, transcripts, etc.), and a throw
+    // would punish fire-and-forget callers more than it would help.
     if (!this.room || !this.socket) {
-      throw new Error(`Cannot send data while not connected. Current status is ${this._status}.`);
+      console.warn(`Dropping '${obj.type}' data message while not connected. Current status is ${this._status}.`);
+      return;
     }
     const msgStr = JSON.stringify(obj);
     const msgBytes = this.textEncoder.encode(msgStr);
@@ -621,7 +628,7 @@ export class UltravoxSession extends EventTarget {
   private invokeClientTool(toolName: string, invocationId: string, parameters: { [key: string]: any }) {
     const tool = this.registeredTools.get(toolName);
     if (!tool) {
-      this.sendClientToolResult({
+      this.sendData({
         type: 'client_tool_result',
         invocationId,
         errorType: 'undefined',
@@ -646,9 +653,9 @@ export class UltravoxSession extends EventTarget {
 
   private handleClientToolResult(invocationId: string, result: any) {
     if (typeof result === 'string') {
-      this.sendClientToolResult({ type: 'client_tool_result', invocationId, result });
+      this.sendData({ type: 'client_tool_result', invocationId, result });
     } else if (typeof result.result !== 'string' || typeof result.responseType !== 'string') {
-      this.sendClientToolResult({
+      this.sendData({
         type: 'client_tool_result',
         invocationId,
         errorType: 'implementation-error',
@@ -656,7 +663,7 @@ export class UltravoxSession extends EventTarget {
           'Client tool result must be a string or an object with string "result" and "responseType" properties.',
       });
     } else {
-      this.sendClientToolResult({
+      this.sendData({
         type: 'client_tool_result',
         invocationId,
         ...result,
@@ -665,20 +672,11 @@ export class UltravoxSession extends EventTarget {
   }
 
   private handleClientToolFailure(invocationId: string, error: any) {
-    this.sendClientToolResult({
+    this.sendData({
       type: 'client_tool_result',
       invocationId,
       errorType: 'implementation-error',
       errorMessage: error instanceof Error ? error.message : undefined,
     });
-  }
-
-  private sendClientToolResult(resultMessage: any) {
-    try {
-      this.sendData(resultMessage);
-    } catch (e) {
-      // The call likely ended while the tool was running, so no one can receive the result.
-      console.warn('Failed to send client tool result:', e);
-    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "inlineSources": true,


### PR DESCRIPTION
## Context

Pre-release batch of SDK updates now that #32 is in.

## Changes

### `user_text_message` with urgency (replaces legacy `input_text_message`)

`sendText` now sends `user_text_message` and accepts `{ urgency, placement }` (new `TextMessageUrgency` / `TextMessagePlacement` enums, matching the server's contract in `data_messages.py`). The old `sendText(text, deferResponse)` boolean form still compiles and works but is `@deprecated`; it maps to urgency `LATER` (true) / `IMMEDIATE` (false), which is exactly the server-side interpretation of the legacy message, so existing callers see no behavior change. A bare `sendText(text)` now leaves urgency to the server default (`soon`) — previously it behaved as immediate; flagging in case you want release notes to mention it.

This was the only stale message type in the SDK — everything else it sends/receives (`set_output_medium`, `client_tool_result`, `state`, `transcript`, `client_tool_invocation`) is current.

### Audio source nodes (also addresses #20)

New lazily-created `session.micSourceNode` / `session.agentSourceNode` getters (`MediaStreamAudioSourceNode`), for attaching analyzers to drive speech indicators. They're created in the session's `AudioContext` (integrators who want to own the graph can pass their own context to the constructor), are `undefined` until the corresponding audio exists, and are disconnected on teardown. This restores (and extends to the mic side) what #30 removed, but nodes are only created if actually requested.

### Server-side hangup verification (the old missing-disconnected-event report)

Verified against fixie: the server ends calls by closing the control websocket (normal ends use code 1000), and `handleSocketClose` → `disconnect()` emits the status events; #32 additionally covers media-side deaths via `RoomEvent.Disconnected`. The renamed test `disconnects without an error when the server hangs up (normal socket close)` pins the exact scenario. One residual way the event could still be lost: an exception from `track.stop()` / `room.disconnect()` during teardown would previously abort `performDisconnect` before the final `DISCONNECTED` status. Those steps are now individually guarded (with a test), so the session always reaches `DISCONNECTED`.

### Hardening / usability

- `sendData` now warns (`console.warn`) and drops the message when there's no transport (previously a fully *silent* drop via optional chaining). It deliberately does not throw: undelivered messages are typically visible through other means (call events, transcripts), so a throw would punish fire-and-forget callers more than it would help. The connectedness check is also unified across both transports, so behavior no longer depends on payload size while connecting, and a large message can no longer go out on the socket before `room_info` is exchanged.
- A socket message arriving after `room_info` is now routed as an ordinary data message instead of being misinterpreted as a second `room_info` (which would have silently created a new Room and wrecked the session). The server sends nothing else over the socket today; this is future-proofing.
- `audioContext.resume()` / `audioElement.play()` rejections (browser autoplay blocking) no longer surface as unhandled promise rejections.
- Fixed the stale class doc (still described the removed `experimental_message` event) and README: documented `sendText` options, `sendData`/`data_message`, audio nodes, the transcript `ordinal` column, and updated the docs link to docs.ultravox.ai.

### Tests

Coverage grows from 10 to 35 tests, all through the public interface against the existing WebSocket/Room fakes: text/data sending (message shapes, urgency mapping, socket-vs-data-channel routing, not-connected errors), state/status, transcripts (deltas, finalization, ordinals), `data_message` cancellation, client tools (string/object/invalid results, sync/async, errors, unregistered, post-hangup), mic/speaker muting (including mute-before-track), audio node lifecycle, teardown resilience, and the server-hangup path.

### Dependencies & release prep

- `livekit-client` 2.16.1 → 2.20.1, `prettier` 3.7.4 → 3.9.4, `tshy` 3.1.0 → 4.1.3, `typescript` 5.9.3 → 7.0.2. The two majors (tshy, TS 7) build clean: `tsc --noEmit`, tshy build, and tests all pass, and the emitted `dist/esm` declarations include the overloads/getters as expected.
- Version bumped to 0.6.0.

## Testing

`pnpm run format:check`, `pnpm exec tsc --noEmit`, `pnpm test` (35 passing), tshy build, plus a smoke-import of the built ESM bundle verifying the new exports and enum values. Not exercised against a live call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
