### PR TITLE
Add the repository field required by npm provenance validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "ultravox-client",
   "version": "0.6.0",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fixie-ai/ultravox-client-sdk-js.git"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Trusted publishing generates provenance by default, and npm validates that `repository.url` in package.json matches the GitHub repository the OIDC token came from — [their docs](https://docs.npmjs.com/trusted-publishers) call this out explicitly. The field was missing entirely, which would have failed the first workflow publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)